### PR TITLE
Implement REST API permissions for staff only

### DIFF
--- a/ACM_General/ACM_General/settings.py
+++ b/ACM_General/ACM_General/settings.py
@@ -49,6 +49,9 @@ AUTHENTICATION_BACKENDS = [
 REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': (
         'django_filters.rest_framework.backends.DjangoFilterBackend',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_api.permissions.IsStaffOrReadonly',
     )
 }
 

--- a/ACM_General/products/models.py
+++ b/ACM_General/products/models.py
@@ -38,6 +38,7 @@ class TransactionCategory(models.Model):
         verbose_name=_('Category Name'),
         help_text=_('The name of the Category'),
         max_length=50,
+        unique=True
     )
 
     def __str__(self):

--- a/ACM_General/rest_api/permissions.py
+++ b/ACM_General/rest_api/permissions.py
@@ -1,28 +1,17 @@
-"""
 from rest_framework import permissions
 
 
-class IsStaffOrReadOnly(permissions.BasePermission):
-
-    Custom permission which only allows admins to edit data.
-
-
-    def has_object_permission(self, request, view, obj):
-        return request.user.is_staff
-
-
-class IsOwnerOrReadOnly(permissions.BasePermission):
-
-    Custom permission which only allows Owners to edit data
-
-    Requires that the Model/Serializer has field email.
-
-    TODO: Make it so that it does not require there to be email.
-
-
-    def has_object_permission(self, request, view, obj):
+class IsStaffOrReadonly(permissions.BasePermission):
+    """
+    Allows only staff members, classified by the `is_staff` method of the User
+    model, to have complete permissions if they are logged in. Otherwise, the
+    Users can only perform the safe methods of GET, HEAD, or OPTIONS.
+    """
+    def has_permission(self, request, view):
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        return request.user.email == obj.email
-"""
+        if not request.user.is_authenticated:
+            return False
+
+        return request.user.is_staff

--- a/ACM_General/rest_api/permissions.py
+++ b/ACM_General/rest_api/permissions.py
@@ -7,7 +7,8 @@ class IsStaffOrReadonly(permissions.BasePermission):
     model, to have complete permissions if they are logged in. Otherwise, the
     Users can only perform the safe methods of GET, HEAD, or OPTIONS.
     """
-    def has_permission(self, request, view):
+    @staticmethod
+    def has_permission(request, view):
         if request.method in permissions.SAFE_METHODS:
             return True
 

--- a/ACM_General/rest_api/tests.py
+++ b/ACM_General/rest_api/tests.py
@@ -161,7 +161,7 @@ class RestAPITestCase(TestCase):
         self.assertEqual(response.status_code, status_code)
         json_response = response.json()
 
-        if test_dict:
+        if test_dict: # pragma: no cover
             test_items = test_dict.items()
             comparitor = lambda x: test_items <= x.items()
             filtered_resp = list(filter(comparitor, json_response))
@@ -378,7 +378,7 @@ class RestAPITestCase(TestCase):
                 reverse(self.detail_path, kwargs={'pk': model_obj_pk_val}),
             )
         else:
-            raise ValueError("Serializer is not valid.")
+            raise ValueError("Serializer is not valid.") # pragma: no cover
 
 
 class AccountsTestCase(RestAPITestCase):

--- a/ACM_General/rest_api/tests.py
+++ b/ACM_General/rest_api/tests.py
@@ -2,7 +2,6 @@
 Contains all of the unit tests for the rest_api app.
 """
 # standard library
-import copy
 import json
 from io import BytesIO
 
@@ -20,6 +19,7 @@ from rest_framework.test import APIClient
 from accounts.models import User
 from accounts.serializers import UserSerializer
 from events.models import Event
+from events.serializers import EventSerializer
 from products.models import Product, Transaction, TransactionCategory
 from products.serializers import (CategorySerializer, ProductSerializer,
                                   TransactionSerializer)
@@ -65,6 +65,19 @@ class RestAPITestCase(TestCase):
         self.client = APIClient()
         self.user = User.objects.create_user('ksyh3@mst.edu')
         self.default_user = User.objects.get(email="acm@mst.edu")
+
+        # Save photo to an in-memory bytes buffer. See
+        # https://stackoverflow.com/questions/48075739/unit-testing-a-django-form-with-a-imagefield-without-external-file.
+        im_io = BytesIO()
+        im = Image.new(mode='RGB', size=(50, 50))
+        im.save(im_io, 'JPEG')
+        # Sets up image variable for creating Event
+        self.image = SimpleUploadedFile(
+            name='test_image.jpg',
+            content=im_io.getvalue(),
+            content_type='multipart/form-data'
+        )
+
         self.sig = SIG.objects.create_sig(
             id='test',
             chair=self.user,
@@ -394,6 +407,9 @@ class AccountsTestCase(RestAPITestCase):
         response = self.client.post(reverse('rest_api:user-list'), user)
         self.assertEqual(response.status_code, 400)
 
+    def test_rest_actions(self):
+        super().test_rest_actions()
+
 
 class EventsTestCase(RestAPITestCase):
     """
@@ -406,17 +422,7 @@ class EventsTestCase(RestAPITestCase):
         functionality.
         """
         super().setUp()
-        # Save photo to an in-memory bytes buffer. See
-        # https://stackoverflow.com/questions/48075739/unit-testing-a-django-form-with-a-imagefield-without-external-file.
-        im_io = BytesIO()
-        im = Image.new(mode='RGB', size=(50, 50))
-        im.save(im_io, 'JPEG')
-        # Sets up image variable for creating Event
-        self.image = SimpleUploadedFile(
-            name='test_image.jpg',
-            content=im_io.getvalue(),
-            content_type='multipart/form-data'
-        )
+
         self.data = {
             "date_hosted": timezone.now(),
             "date_expire": timezone.now(),
@@ -442,10 +448,13 @@ class EventsTestCase(RestAPITestCase):
             "hosting_sig": str(self.sig.id),
         }
         self.model = Event
-        self.serializer = SIGSerializer
+        self.serializer = EventSerializer
         self.list_path = 'rest_api:event-list'
         self.detail_path = 'rest_api:event-detail'
         self.content_type = "multipart/form"
+
+    def test_rest_actions(self):
+        super().test_rest_actions()
 
 
 class SigsTestCase(RestAPITestCase):
@@ -478,6 +487,9 @@ class SigsTestCase(RestAPITestCase):
         self.list_path = 'rest_api:sig-list'
         self.detail_path = 'rest_api:sig-detail'
         self.content_type = "application/json"
+
+    def test_rest_actions(self):
+        super().test_rest_actions()
 
 
 class TransactionsTestCase(RestAPITestCase):
@@ -522,6 +534,9 @@ class TransactionsTestCase(RestAPITestCase):
         self.detail_path = 'rest_api:transaction-detail'
         self.content_type = "application/json"
 
+    def test_rest_actions(self):
+        super().test_rest_actions()
+
 
 class CategoryTestCase(RestAPITestCase):
     """
@@ -547,6 +562,9 @@ class CategoryTestCase(RestAPITestCase):
         self.list_path = 'rest_api:category-list'
         self.detail_path = 'rest_api:category-detail'
         self.content_type = "application/json"
+
+    def test_rest_actions(self):
+        super().test_rest_actions()
 
 
 class ProductTestCase(RestAPITestCase):
@@ -582,3 +600,6 @@ class ProductTestCase(RestAPITestCase):
         self.list_path = 'rest_api:product-list'
         self.detail_path = 'rest_api:product-detail'
         self.content_type = "application/json"
+
+    def test_rest_actions(self):
+        super().test_rest_actions()

--- a/ACM_General/rest_api/tests.py
+++ b/ACM_General/rest_api/tests.py
@@ -347,7 +347,7 @@ class RestAPITestCase(TestCase):
         """
         self.client.force_login(self.default_user)
 
-    def test_rest_actions(self):
+    def assert_generic_rest_actions(self):
         """
         Ensures that the rest actions for the model specified in the class
         returns the proper results for the GET, POST, PUT, and DELETE methods.
@@ -363,7 +363,7 @@ class RestAPITestCase(TestCase):
             data, mod_data, self.model, self.content_type
         )
 
-    def test_rest_actions_without_permissions(self):
+    def assert_rest_actions_without_permissions(self):
         """
         Ensures that the rest actions for the model specified in the class fails
         if the user does not have the proper permissions.
@@ -429,7 +429,10 @@ class AccountsTestCase(RestAPITestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_rest_actions(self):
-        super().test_rest_actions()
+        self.assert_generic_rest_actions()
+
+    def test_rest_actions_without_permissions(self):
+        self.assert_rest_actions_without_permissions()
 
 
 class EventsTestCase(RestAPITestCase):
@@ -466,7 +469,10 @@ class EventsTestCase(RestAPITestCase):
         self.content_type = "multipart/form-data"
 
     def test_rest_actions(self):
-        super().test_rest_actions()
+        self.assert_generic_rest_actions()
+
+    def test_rest_actions_without_permissions(self):
+        self.assert_rest_actions_without_permissions()
 
 
 class SigsTestCase(RestAPITestCase):
@@ -501,7 +507,10 @@ class SigsTestCase(RestAPITestCase):
         self.content_type = "application/json"
 
     def test_rest_actions(self):
-        super().test_rest_actions()
+        self.assert_generic_rest_actions()
+
+    def test_rest_actions_without_permissions(self):
+        self.assert_rest_actions_without_permissions()
 
 
 class TransactionsTestCase(RestAPITestCase):
@@ -547,7 +556,10 @@ class TransactionsTestCase(RestAPITestCase):
         self.content_type = "application/json"
 
     def test_rest_actions(self):
-        super().test_rest_actions()
+        self.assert_generic_rest_actions()
+
+    def test_rest_actions_without_permissions(self):
+        self.assert_rest_actions_without_permissions()
 
 
 class CategoryTestCase(RestAPITestCase):
@@ -576,7 +588,10 @@ class CategoryTestCase(RestAPITestCase):
         self.content_type = "application/json"
 
     def test_rest_actions(self):
-        super().test_rest_actions()
+        self.assert_generic_rest_actions()
+
+    def test_rest_actions_without_permissions(self):
+        self.assert_rest_actions_without_permissions()
 
 
 class ProductTestCase(RestAPITestCase):
@@ -614,4 +629,7 @@ class ProductTestCase(RestAPITestCase):
         self.content_type = "application/json"
 
     def test_rest_actions(self):
-        super().test_rest_actions()
+        self.assert_generic_rest_actions()
+
+    def test_rest_actions_without_permissions(self):
+        self.assert_rest_actions_without_permissions()


### PR DESCRIPTION
Restricts the REST API permissions to only allow staff to have complete
permissions on the API. All other users only have access to "safe"
permissions that does not modify any data.

Moreover, the REST API tests have been completely refactored to be much
more generic.

closes: #177